### PR TITLE
Issue 27

### DIFF
--- a/roles/tendrl-storage-node/README.md
+++ b/roles/tendrl-storage-node/README.md
@@ -22,8 +22,6 @@ update related role variables (see details below).
 Role Variables
 --------------
 
-* When `tendrl_gluster_provisioning_support` variable is `True`, support for
-  gluster provisioning will be enabled (default is False).
 * Variable `etcd_ip_address` needs to be set to ipv4 adress of etcd instance.
   Specifying this variable is mandatory as there is no default value.
 * Variable `graphite_ip_address` needs to be set to ipv4 adress of graphite

--- a/roles/tendrl-storage-node/defaults/main.yml
+++ b/roles/tendrl-storage-node/defaults/main.yml
@@ -1,6 +1,2 @@
 ---
 # defaults file for tendrl-node
-
-# Should Tendrl be able to provision new Gluster cluster? Requires Gluster
-# rpm repositories (gdeploy) to be available.
-tendrl_gluster_provisioning_support: False

--- a/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
@@ -18,16 +18,6 @@
   notify:
     - restart tendrl-node-agent
 
-- name: Add provisioner/gluster tag into node-agent.conf.yaml
-  lineinfile:
-    dest: /etc/tendrl/node-agent/node-agent.conf.yaml
-    insertafter: '^tags:$'
-    line: "  - provisioner/gluster"
-  notify:
-    - restart tendrl-node-agent
-  when: tendrl_gluster_provisioning_support == True
-  run_once: true
-
 - name: Enable tendrl-node-agent service
   service:
     name=tendrl-node-agent

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -94,5 +94,4 @@
     graphite_ip_address: "{{ hostvars[groups['tendrl-server'][0]].ansible_default_ipv4.address }}"
   roles:
     - tendrl-copr
-    # - gluster-gdeploy-copr
     - tendrl-storage-node

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -92,7 +92,6 @@
     # make sure this value is the same
     etcd_ip_address: "{{ hostvars[groups['tendrl-server'][0]].ansible_default_ipv4.address }}"
     graphite_ip_address: "{{ hostvars[groups['tendrl-server'][0]].ansible_default_ipv4.address }}"
-    tendrl_gluster_provisioning_support: False
   roles:
     - tendrl-copr
     # - gluster-gdeploy-copr


### PR DESCRIPTION
Remove `tendrl_gluster_provisioning_support` variable (which sets `provisioner/gluster` tag), because this option is no longer needed.

Fixing https://github.com/Tendrl/tendrl-ansible/issues/27