### PR TITLE
Replacing grafana.ini file path in /etc/sysconfig/grafana-server

### DIFF
--- a/roles/tendrl-server/handlers/main.yml
+++ b/roles/tendrl-server/handlers/main.yml
@@ -25,3 +25,8 @@
   service:
     name=tendrl-monitoring-integration
     state=restarted
+
+- name: restart grafana-server
+  service:
+    name=grafana-server
+    state=restarted

--- a/roles/tendrl-server/tasks/tendrl-monitoring-integration.yml
+++ b/roles/tendrl-server/tasks/tendrl-monitoring-integration.yml
@@ -37,6 +37,19 @@
  # grafana configuration
  #
 
+- name: Configure grafana to use tendrl-monitoring-integration config
+  lineinfile:
+    dest=/etc/sysconfig/grafana-server
+    regexp={{ item.regexp }}
+    line={{ item.line }}
+  with_items:
+    - regexp: '^CONF_DIR=.*'
+      line: "CONF_DIR=/etc/tendrl/monitoring-integration/grafana/"
+    - regexp: '^CONF_FILE=.*'
+      line: "CONF_FILE=/etc/tendrl/monitoring-integration/grafana/grafana.ini"
+  notify:
+    - restart grafana-server
+
 - name: Enable grafana-server service
   service:
     name=grafana-server

--- a/roles/tendrl-server/tasks/tendrl-monitoring-integration.yml
+++ b/roles/tendrl-server/tasks/tendrl-monitoring-integration.yml
@@ -5,6 +5,10 @@
     name=tendrl-monitoring-integration
     state=latest
 
+#
+# graphite (consists of carbon, whisper and graphite web) configuration
+#
+
 - name: Initialize graphite-db
   command: /usr/lib/python2.7/site-packages/graphite/manage.py syncdb --noinput
   args:
@@ -29,6 +33,10 @@
     name=carbon-cache
     enabled=yes
 
+ #
+ # grafana configuration
+ #
+
 - name: Enable grafana-server service
   service:
     name=grafana-server
@@ -39,6 +47,10 @@
   service:
     name=grafana-server
     state=started
+
+#
+# configuration of monitoring integration itself
+#
 
 - name: Configure tendrl-monitoring-integration
   lineinfile:


### PR DESCRIPTION
This pull request implements https://github.com/Tendrl/tendrl-ansible/issues/29 by reconfiguring grafana to use config files provided by tendrl-monitoring-package.