### PR TITLE
Enable etcd user and password based authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 site.yml
 # vagrant files
 .vagrant
+# ansible password lookup files
+etcd_root_passwd

--- a/roles/tendrl-server/README.md
+++ b/roles/tendrl-server/README.md
@@ -31,22 +31,38 @@ If you want to be able to provision Ceph clusters with Tendrl, use role
 Role Variables
 --------------
 
-* When `etcd_ip_address` variable is undefined (which is the default state),
-  this role will use ip address of default ipv4 network interface to configure
-  etcd, otherwise a value of this variable will be used.
-* When `graphite_ip_address` variable is undefined (which is the default
-  state), this role will use ip address of default ipv4 network interface,
-  otherwise a value of this variable will be used.
-* When `graphite_port` variable is undefined, task which configures graphite
-  port for `tendrl-node-agent` will be skipped so that the default value from
-  config file (as shipped in rpm package) will be used. *If you are not sure*
-  if you need to reconfigure this, *leave this variable undefined*.
-* When `etcd_authentication` variable is undefined or set to `True` (which is
-  the default value), this role will configure [etcd
-  authentication](https://coreos.com/etcd/docs/latest/op-guide/authentication.html).
-  When the value is `False`, the authentication will be disabled, which is
-  useful for development/testing purposes only. For production, keep the
-  authentication always enabled.
+ *  When `etcd_ip_address` variable is undefined (which is the default state),
+    this role will use ip address of default ipv4 network interface to
+    configure etcd, otherwise a value of this variable will be used.
+
+ *  When `graphite_ip_address` variable is undefined (which is the default
+    state), this role will use ip address of default ipv4 network interface,
+    otherwise a value of this variable will be used.
+
+ *  When `graphite_port` variable is undefined, task which configures graphite
+    port for `tendrl-node-agent` will be skipped so that the default value from
+    config file (as shipped in rpm package) will be used. *If you are not sure*
+    if you need to reconfigure this, *leave this variable undefined*.
+
+ *  When `etcd_authentication` variable is undefined or set to `True` (which is
+    the default value), this role will enable [etcd
+    authentication](https://coreos.com/etcd/docs/latest/op-guide/authentication.html)
+    and configure tendrl components accordingly.
+
+    When the value is `False`, ansible would just skip all etcd authentication
+    tasks (icluding both etcd auth setup and tendrl configuration),
+    which means that if the etcd auth has been already enabled, it will still
+    be enabled and when etcd auth is disabled, it will continue to be disabled.
+    In other words, **this role can't disable nor reconfigura etcd
+    authentication, it can only skip etcd auth setup and config tasks**.
+
+    This means that the only way to disable etcd authentication is to set
+    `etcd_authentication` to `False` for the 1st time you run ansible to deploy
+    Tendrl, and keep it this way every other run of tendrl-ansible.
+
+    Note that having etcd authentication disabled is useful for
+    development/testing purposes only. For production, keep the authentication
+    always enabled.
 
 License
 -------

--- a/roles/tendrl-server/README.md
+++ b/roles/tendrl-server/README.md
@@ -56,7 +56,8 @@ Role Variables
     In other words, **this role can't disable nor reconfigura etcd
     authentication, it can only skip etcd auth setup and config tasks**.
 
-    This means that the only way to disable etcd authentication is to set
+    Since authentication is disabled in etcd by default, the only way to
+    configure Tendrl to run without etcd authentication is to set
     `etcd_authentication` to `False` for the 1st time you run ansible to deploy
     Tendrl, and keep it this way every other run of tendrl-ansible.
 

--- a/roles/tendrl-server/README.md
+++ b/roles/tendrl-server/README.md
@@ -10,6 +10,15 @@ with both api and web interface), and that new random default password is
 stored on *Tendrl Server* machine in `/root/password` file (based on
 [TEN-257](https://tendrl.atlassian.net/browse/TEN-257)).
 
+Also note that this role enables [etcd
+authentication](https://coreos.com/etcd/docs/latest/op-guide/authentication.html)
+by default (see description of `etcd_authentication` variable below), creating
+etcd root user account with new default random password via [ansible password
+lookup
+plugin](https://docs.ansible.com/ansible/latest/playbooks_lookups.html#the-password-lookup).
+This means that the password of etcd root user will be stored in current working
+directory (from where you run ansible), in `etcd_root_passwd` file.
+
 Requirements
 ------------
 
@@ -32,6 +41,12 @@ Role Variables
   port for `tendrl-node-agent` will be skipped so that the default value from
   config file (as shipped in rpm package) will be used. *If you are not sure*
   if you need to reconfigure this, *leave this variable undefined*.
+* When `etcd_authentication` variable is undefined or set to `True` (which is
+  the default value), this role will configure [etcd
+  authentication](https://coreos.com/etcd/docs/latest/op-guide/authentication.html).
+  When the value is `False`, the authentication will be disabled, which is
+  useful for development/testing purposes only. For production, keep the
+  authentication always enabled.
 
 License
 -------

--- a/roles/tendrl-server/defaults/main.yml
+++ b/roles/tendrl-server/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for tendrl-server
+etcd_authentication: True

--- a/roles/tendrl-server/tasks/etcd.yml
+++ b/roles/tendrl-server/tasks/etcd.yml
@@ -68,6 +68,11 @@
       - "another option is to skip etcd auth configuration by setting etcd_authentication ansible variable to False"
   when: is_etcd_auth_already_enabled == True and stat_etcd_root_passwd['stat']['exists'] == False and etcd_authentication == True
 
+- name: Make it clear that we will not disable etcd auth when etcd_authentication == False
+  debug:
+    msg: "Since etcd_authentication == False, tasks dealing with etcd auth are just skipped."
+  when: is_etcd_auth_already_enabled == True and etcd_authentication == False
+
 - name: Add etcd root user account
   command: etcdctl --endpoints http://{{ etcd_ip_address }}:2379 user add root:{{ lookup('password', 'etcd_root_passwd chars=ascii_letters length=30') }}
   when: etcd_authentication == True and is_etcd_auth_already_enabled == False

--- a/roles/tendrl-server/tasks/etcd.yml
+++ b/roles/tendrl-server/tasks/etcd.yml
@@ -32,4 +32,35 @@
     name=etcd
     state=started
 
+#
+# https://coreos.com/etcd/docs/latest/op-guide/authentication.html
+#
+
+- name: Detection of current etcd authentication mode (etcdctl run)
+  command: etcdctl --endpoints http://{{ etcd_ip_address }}:2379 user list
+  when: etcd_authentication == True
+  changed_when: False
+  failed_when: False
+  register: detect_etcd_auth
+
+- name: Detection of current etcd authentication mode (checking stderr)
+  set_fact:
+    is_etcd_auth_already_enabled: "{{ 'Insufficient credentials' in detect_etcd_auth.stderr }}"
+
+- name: Detected status of etcd authentication (based on previous etcdctl run)
+  debug:
+    var: is_etcd_auth_already_enabled
+
+- name: Add etcd root user account
+  command: etcdctl --endpoints http://{{ etcd_ip_address }}:2379 user add root:{{ lookup('password', 'etcd_root_passwd chars=ascii_letters length=30') }}
+  when: etcd_authentication == True and is_etcd_auth_already_enabled == False
+
+- name: Enable etcd authentication
+  command: etcdctl --endpoints http://{{ etcd_ip_address }}:2379 auth enable
+  when: etcd_authentication == True and is_etcd_auth_already_enabled == False
+
+- name: Remove etcd guest group
+  command: etcdctl --endpoints http://{{ etcd_ip_address }}:2379 --username root:{{ lookup('password', 'etcd_root_passwd chars=ascii_letters length=30') }} role remove guest
+  when: etcd_authentication == True and is_etcd_auth_already_enabled == False
+
 - meta: flush_handlers

--- a/roles/tendrl-server/tasks/etcd.yml
+++ b/roles/tendrl-server/tasks/etcd.yml
@@ -38,7 +38,6 @@
 
 - name: Detection of current etcd authentication mode (etcdctl run)
   command: etcdctl --endpoints http://{{ etcd_ip_address }}:2379 user list
-  when: etcd_authentication == True
   changed_when: False
   failed_when: False
   register: detect_etcd_auth
@@ -47,9 +46,27 @@
   set_fact:
     is_etcd_auth_already_enabled: "{{ 'Insufficient credentials' in detect_etcd_auth.stderr }}"
 
-- name: Detected status of etcd authentication (based on previous etcdctl run)
+- name: Detected status of etcd authentication (based on previous tasks)
   debug:
     var: is_etcd_auth_already_enabled
+
+- name: Detection if etcd_root_passwd (ansible password lookup file) exists
+  local_action: stat path=etcd_root_passwd
+  register: stat_etcd_root_passwd
+  run_once: True
+
+- name: Detected status of local etcd_root_passwd file (based on previous task)
+  debug:
+    var: stat_etcd_root_passwd['stat']['exists']
+
+- name: Prevent breaking etcd auth configuration when necessary
+  fail:
+    msg:
+      - "etcd auth is already enabled, but etcd_root_passwd file is missing"
+      - "to prevent misconfiguration of the cluster, ansible run stopped"
+      - "you need to save etcd root admin password into local etcd_root_passwd file to be able to run this playbook again"
+      - "another option is to skip etcd auth configuration by setting etcd_authentication ansible variable to False"
+  when: is_etcd_auth_already_enabled == True and stat_etcd_root_passwd['stat']['exists'] == False and etcd_authentication == True
 
 - name: Add etcd root user account
   command: etcdctl --endpoints http://{{ etcd_ip_address }}:2379 user add root:{{ lookup('password', 'etcd_root_passwd chars=ascii_letters length=30') }}

--- a/roles/tendrl-server/tasks/tendrl-api.yml
+++ b/roles/tendrl-server/tasks/tendrl-api.yml
@@ -13,15 +13,6 @@
   notify:
     - restart tendrl-api
 
-- name: Configure tendrl-api etcd.yml user_name to empty string
-  replace:
-    dest: /etc/tendrl/etcd.yml
-    regexp: "^ +:user_name:.*"
-    replace: "  :user_name: ''"
-  notify:
-    - restart tendrl-api
-  when: etcd_authentication == False
-
 - name: Configure tendrl-api etcd.yml user_name
   replace:
     dest: /etc/tendrl/etcd.yml
@@ -30,15 +21,6 @@
   notify:
     - restart tendrl-api
   when: etcd_authentication == True
-
-- name: Configure tendrl-api etcd.yml password to empty string
-  replace:
-    dest: /etc/tendrl/etcd.yml
-    regexp: "^ +:password:.*"
-    replace: "  :password: ''"
-  notify:
-    - restart tendrl-api
-  when: etcd_authentication == False
 
 - name: Configure tendrl-api etcd.yml password
   replace:

--- a/roles/tendrl-server/tasks/tendrl-api.yml
+++ b/roles/tendrl-server/tasks/tendrl-api.yml
@@ -13,21 +13,41 @@
   notify:
     - restart tendrl-api
 
-- name: Configure tendrl-api etcd.yml user_name
+- name: Configure tendrl-api etcd.yml user_name to empty string
   replace:
     dest: /etc/tendrl/etcd.yml
     regexp: "^ +:user_name:.*"
     replace: "  :user_name: ''"
   notify:
     - restart tendrl-api
+  when: etcd_authentication == False
 
-- name: Configure tendrl-api etcd.yml password
+- name: Configure tendrl-api etcd.yml user_name
+  replace:
+    dest: /etc/tendrl/etcd.yml
+    regexp: "^ +:user_name:.*"
+    replace: "  :user_name: 'root'"
+  notify:
+    - restart tendrl-api
+  when: etcd_authentication == True
+
+- name: Configure tendrl-api etcd.yml password to empty string
   replace:
     dest: /etc/tendrl/etcd.yml
     regexp: "^ +:password:.*"
     replace: "  :password: ''"
   notify:
     - restart tendrl-api
+  when: etcd_authentication == False
+
+- name: Configure tendrl-api etcd.yml password
+  replace:
+    dest: /etc/tendrl/etcd.yml
+    regexp: "^ +:password:.*"
+    replace: "  :password: '{{ lookup('password', 'etcd_root_passwd') }}'"
+  notify:
+    - restart tendrl-api
+  when: etcd_authentication == True
 
 # based on description from:
 # https://github.com/Tendrl/api/blob/master/docs/users.adoc#create-admin-user

--- a/roles/tendrl-server/tasks/tendrl-monitoring-integration.yml
+++ b/roles/tendrl-server/tasks/tendrl-monitoring-integration.yml
@@ -78,6 +78,20 @@
   notify:
     - restart tendrl-monitoring-integration
 
+- name: Configure etcd username and password in monitoring-integration.conf.yaml
+  lineinfile:
+    dest: /etc/tendrl/monitoring-integration/monitoring-integration.conf.yaml
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  with_items:
+    - regexp: '^#? *etcd_username:.*'
+      line: "etcd_username: root"
+    - regexp: '^#? *etcd_password:.*'
+      line: "etcd_password: {{ lookup('password', 'etcd_root_passwd') }}"
+  notify:
+    - restart tendrl-monitoring-integration
+  when: etcd_authentication == True
+
 - name: Start tendrl-monitoring-integration service
   service:
     name=tendrl-monitoring-integration

--- a/roles/tendrl-server/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-server/tasks/tendrl-node-agent.yml
@@ -18,6 +18,20 @@
   notify:
     - restart tendrl-node-agent
 
+- name: Configure etcd username and password in node-agent.conf.yaml
+  lineinfile:
+    dest: /etc/tendrl/node-agent/node-agent.conf.yaml
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  with_items:
+    - regexp: '^#? *etcd_username:.*'
+      line: "etcd_username: root"
+    - regexp: '^#? *etcd_password:.*'
+      line: "etcd_password: {{ lookup('password', 'etcd_root_passwd') }}"
+  notify:
+    - restart tendrl-node-agent
+  when: etcd_authentication == True
+
 - name: Configure graphite_port in node-agent.conf.yaml (only when needed)
   lineinfile:
     dest: /etc/tendrl/node-agent/node-agent.conf.yaml

--- a/roles/tendrl-storage-node/README.md
+++ b/roles/tendrl-storage-node/README.md
@@ -14,14 +14,23 @@ dependencies) are already available on the machine.
 Role Variables
 --------------
 
-* Variable `etcd_ip_address` needs to be set to ipv4 adress of etcd instance.
-  Specifying this variable is mandatory as there is no default value.
-* Variable `graphite_ip_address` needs to be set to ipv4 adress of graphite
-  instance. Specifying this variable is mandatory as there is no default value.
-* When `etcd_authentication` variable is undefined or set to `True` (which is
-  the default value), this role will specify etcd username and password in
-  tendrl config files. When the value is `False`, the authentication will be
-  disabled. For production, keep the authentication always enabled.
+ *  Variable `etcd_ip_address` needs to be set to ipv4 adress of etcd instance.
+    Specifying this variable is mandatory as there is no default value.
+
+ *  Variable `graphite_ip_address` needs to be set to ipv4 adress of graphite
+    instance. Specifying this variable is mandatory as there is no default
+    value.
+
+ *  When `etcd_authentication` variable is undefined or set to `True` (which is
+    the default value), this role will specify etcd username and password in
+    tendrl config files.
+
+    When the value of `etcd_authentication` is `False`, ansible tasks which
+    configures etcd credentials will be just skipped.
+    In other words, **this role can't disable or reconfigure etcd
+    authentication, it can only skip auth config tasks**.
+
+    For production, keep the authentication always enabled.
 
 Note that values specified in variables of this role need to match variables
 of *Tendrl Server* role.

--- a/roles/tendrl-storage-node/README.md
+++ b/roles/tendrl-storage-node/README.md
@@ -18,6 +18,13 @@ Role Variables
   Specifying this variable is mandatory as there is no default value.
 * Variable `graphite_ip_address` needs to be set to ipv4 adress of graphite
   instance. Specifying this variable is mandatory as there is no default value.
+* When `etcd_authentication` variable is undefined or set to `True` (which is
+  the default value), this role will specify etcd username and password in
+  tendrl config files. When the value is `False`, the authentication will be
+  disabled. For production, keep the authentication always enabled.
+
+Note that values specified in variables of this role need to match variables
+of *Tendrl Server* role.
 
 License
 -------

--- a/roles/tendrl-storage-node/defaults/main.yml
+++ b/roles/tendrl-storage-node/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for tendrl-node
+etcd_authentication: True

--- a/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
@@ -18,6 +18,20 @@
   notify:
     - restart tendrl-node-agent
 
+- name: Configure etcd username and password in node-agent.conf.yaml
+  lineinfile:
+    dest: /etc/tendrl/node-agent/node-agent.conf.yaml
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  with_items:
+    - regexp: '^#? *etcd_username:.*'
+      line: "etcd_username: root"
+    - regexp: '^#? *etcd_password:.*'
+      line: "etcd_password: {{ lookup('password', 'etcd_root_passwd') }}"
+  notify:
+    - restart tendrl-node-agent
+  when: etcd_authentication == True
+
 - name: Enable tendrl-node-agent service
   service:
     name=tendrl-node-agent

--- a/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
@@ -18,6 +18,22 @@
   notify:
     - restart tendrl-node-agent
 
+- name: Detection if etcd_root_passwd (ansible password lookup file) exists
+  local_action: stat path=etcd_root_passwd
+  register: stat_etcd_root_passwd
+  run_once: True
+  when: etcd_authentication == True
+
+- name: Make sure that etcd_root_passwd (ansible password lookup file) exists
+  fail:
+    msg:
+      - "to configure etcd credentials in tendrl config files, etcd_root_passwd (ansible password lookup) file is required"
+      - "since etcd_root_passwd is missing, we can't continue"
+      - "under normal conditions, etcd_root_passwd is created by ansible when tendrl-server role is executed"
+  when: etcd_authentication == True and stat_etcd_root_passwd['stat']['exists'] == False
+  run_once: True
+  delegate_to: localhost
+
 - name: Configure etcd username and password in node-agent.conf.yaml
   lineinfile:
     dest: /etc/tendrl/node-agent/node-agent.conf.yaml


### PR DESCRIPTION
This pull request adds setup of etcd authentication.

Change of etcd password or username when etcd auth is aready enabled is not implemented.

Resolves issue https://github.com/Tendrl/tendrl-ansible/issues/34