### PR TITLE
tendrl-server: create and configure grafana password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ site.yml
 .vagrant
 # ansible password lookup files
 etcd_root_passwd
+grafana_admin_passwd

--- a/roles/tendrl-server/README.md
+++ b/roles/tendrl-server/README.md
@@ -17,7 +17,16 @@ etcd root user account with new default random password via [ansible password
 lookup
 plugin](https://docs.ansible.com/ansible/latest/playbooks_lookups.html#the-password-lookup).
 This means that the password of etcd root user will be stored in current working
-directory (from where you run ansible), in `etcd_root_passwd` file.
+directory (from where you run ansible), in `etcd_root_passwd` file. Don't
+delete this password file, as this role can't regenerate etcd root password.
+
+Moreover it also generates new random password for grafana admin user account
+via [ansible password lookup
+plugin](https://docs.ansible.com/ansible/latest/playbooks_lookups.html#the-password-lookup),
+which is then stored in `grafana_admin_passwd` file in current working
+directory. To regenerate this password, you can safely delete this password
+lookup file and rerun the playbook, new password will be generated and all
+affected components reconfigured.
 
 Requirements
 ------------

--- a/roles/tendrl-server/tasks/tendrl-monitoring-integration.yml
+++ b/roles/tendrl-server/tasks/tendrl-monitoring-integration.yml
@@ -52,7 +52,7 @@
 
 - name: Configure admin password for grafana
   ini_file:
-    path: /etc/grafana/grafana.ini
+    path: /etc/tendrl/monitoring-integration/grafana/grafana.ini
     section: security
     option: admin_password
     value: "{{ lookup('password', 'grafana_admin_passwd chars=ascii_letters length=30') }}"

--- a/roles/tendrl-server/tasks/tendrl-monitoring-integration.yml
+++ b/roles/tendrl-server/tasks/tendrl-monitoring-integration.yml
@@ -50,6 +50,15 @@
   notify:
     - restart grafana-server
 
+- name: Configure admin password for grafana
+  ini_file:
+    path: /etc/grafana/grafana.ini
+    section: security
+    option: admin_password
+    value: "{{ lookup('password', 'grafana_admin_passwd chars=ascii_letters length=30') }}"
+  notify:
+    - restart grafana-server
+
 - name: Enable grafana-server service
   service:
     name=grafana-server
@@ -91,6 +100,15 @@
   notify:
     - restart tendrl-monitoring-integration
   when: etcd_authentication == True
+
+- name: Configure grafana admin password in monitoring-integration.conf.yaml
+  lineinfile:
+    dest: /etc/tendrl/monitoring-integration/monitoring-integration.conf.yaml
+    insertafter: 'credentials:'
+    regexp: '^  password:.*'
+    line: "  password: {{ lookup('password', 'grafana_admin_passwd') }}"
+  notify:
+    - restart tendrl-monitoring-integration
 
 - name: Start tendrl-monitoring-integration service
   service:


### PR DESCRIPTION
New random password for grafana admin is generated, and affected components
(grafana and tednrl monitoring integration) are reconfigured.

Addressing https://github.com/Tendrl/tendrl-ansible/issues/32
