### PR TITLE
etcd client-server tls auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ tendrl.example.com
 ```
 
 4) Create `site.yml` file based on `site.yml.sample` and make sure to
-   define `etcd_ip_address` to suit
+   define all ansible variables there to suit.
 5) Run `$ ansible-playbook -i inventory_file site.yml`
 6) Log in to your tendrl server at ``http://ip.of.tendrl.server`` with
    ``admin`` user and the default password ``adminuser``.

--- a/roles/tendrl-server/README.md
+++ b/roles/tendrl-server/README.md
@@ -31,9 +31,25 @@ If you want to be able to provision Ceph clusters with Tendrl, use role
 Role Variables
 --------------
 
- *  When `etcd_ip_address` variable is undefined (which is the default state),
-    this role will use ip address of default ipv4 network interface to
-    configure etcd, otherwise a value of this variable will be used.
+ *  Variable `etcd_ip_address` is mandatory, when you let this variable
+    undefined, installation will fail.
+
+    Value of `etcd_ip_address` is used to configure where etcd instance is
+    listening.
+
+    If you provide a hostname instead of an ip address there, etcd instance may
+    fail to even start. Note that etcd upstream requires to use ip address for
+    this configuration.
+
+ *  Variable `etcd_fqdn` is mandatory, when you let this variable undefined,
+    installation will fail.
+
+    Value of this variable is used to configure tendrl components to be able
+    to connect to etcd instance (aka tednrl central store).
+
+    If you provide an ip address instead of fqdn there, tendrl components
+    may fail to start or even crash. Note that etcd upstream requires to use
+    fqdn for this configuration.
 
  *  When `graphite_ip_address` variable is undefined (which is the default
     state), this role will use ip address of default ipv4 network interface,

--- a/roles/tendrl-server/README.md
+++ b/roles/tendrl-server/README.md
@@ -51,9 +51,12 @@ Role Variables
     may fail to start or even crash. Note that etcd upstream requires to use
     fqdn for this configuration.
 
- *  When `graphite_ip_address` variable is undefined (which is the default
-    state), this role will use ip address of default ipv4 network interface,
-    otherwise a value of this variable will be used.
+ *  Variable `graphite_fqdn` is mandatory, when you let this variable undefined,
+    installation will fail.
+
+    Value of this variable is used to configure tendrl components
+    (this value doesn't reconfigure graphite itself!) to be able to connect to
+    graphite instance (carbon-cache service in particular).
 
  *  When `graphite_port` variable is undefined, task which configures graphite
     port for `tendrl-node-agent` will be skipped so that the default value from

--- a/roles/tendrl-server/README.md
+++ b/roles/tendrl-server/README.md
@@ -49,7 +49,9 @@ Role Variables
 
     If you provide an ip address instead of fqdn there, tendrl components
     may fail to start or even crash. Note that etcd upstream requires to use
-    fqdn for this configuration.
+    fqdn for this configuration. See:
+
+    https://github.com/Tendrl/commons/issues/759
 
  *  Variable `graphite_fqdn` is mandatory, when you let this variable undefined,
     installation will fail.

--- a/roles/tendrl-server/README.md
+++ b/roles/tendrl-server/README.md
@@ -44,6 +44,46 @@ Role Variables
     config file (as shipped in rpm package) will be used. *If you are not sure*
     if you need to reconfigure this, *leave this variable undefined*.
 
+ *  When `etcd_tls_client_auth` is set to False (which is the default state),
+    etcd will work without any authentication (default etcd behavior).
+
+    When `etcd_tls_client_auth` is True, etcd will be reconfigured to use
+    client to server authentication with HTTPS client certificates, and all
+    Tendrl components will be reconfigured accordingly.
+
+    Note that tendrl-ansible is not concerned with issuing and deployment of
+    certificates. So for etcd tcl client authentication to work, *you need to
+    issue and deploy tls certificates for all machines of the Tendrl cluster*
+    (including storage nodes and Tendrl server) *before running
+    tendrl-ansible*.
+
+    The placement of tls cert files can be tweaked via ansible variables
+    explained below.
+
+    For more details, see:
+
+    * [Red Hat Enterprise Linux 7 - Security Guide - Using OpenSSL](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-using_openssl)
+    * [Etcd Security model](https://coreos.com/etcd/docs/latest/op-guide/security.html)
+
+ *  Variable `etcd_cert_file` specifies full filepath of `ETCD_CERT_FILE` etcd
+    option. The default value is `/etc/pki/tls/certs/etcd.crt`.
+
+    For more details, see [Etcd Security
+    model](https://coreos.com/etcd/docs/latest/op-guide/security.html)
+
+ *  Variable `etcd_key_file` specifies full filepath of `ETCD_KEY_FILE` etcd
+    option. The default value is `/etc/pki/tls/private/etcd.key`.
+
+    For more details, see [Etcd Security
+    model](https://coreos.com/etcd/docs/latest/op-guide/security.html)
+
+ *  Variable `etcd_trusted_ca_file` specifies full filepath of
+    `ETCD_TRUSTED_CA_FILE` etcd option. The default value is
+    `/etc/pki/tls/certs/ca-etcd.crt`.
+
+    For more details, see [Etcd Security
+    model](https://coreos.com/etcd/docs/latest/op-guide/security.html)
+
  *  When one or both of variables `tendrl_notifier_email_id` and
     `tendrl_notifier_email_smtp_server` is undefined (which is
     the default state for both variables), email configuration of

--- a/roles/tendrl-server/defaults/main.yml
+++ b/roles/tendrl-server/defaults/main.yml
@@ -1,3 +1,9 @@
 ---
 # defaults file for tendrl-server
 tendrl_notifier_email_smtp_port: 25
+etcd_tls_client_auth: False
+# default paths for etcd ssl files based on
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-using_openssl
+etcd_cert_file: "/etc/pki/tls/certs/etcd.crt"
+etcd_key_file: "/etc/pki/tls/private/etcd.key"
+etcd_trusted_ca_file: "/etc/pki/tls/certs/ca-etcd.crt"

--- a/roles/tendrl-server/tasks/etcd.yml
+++ b/roles/tendrl-server/tasks/etcd.yml
@@ -6,11 +6,19 @@
     name=etcd
     state=present
 
+- name: Use http as protocol in etcd urls
+  set_fact: etcd_url_protocol="http"
+  when: etcd_tls_client_auth == False
+
+- name: Use http as protocol in etcd urls
+  set_fact: etcd_url_protocol="https"
+  when: etcd_tls_client_auth == True
+
 - name: Configure etcd.conf ETCD_LISTEN_CLIENT_URLS
   lineinfile:
     dest=/etc/etcd/etcd.conf
     regexp="^(\#*)ETCD_LISTEN_CLIENT_URLS(.*)"
-    line="ETCD_LISTEN_CLIENT_URLS=\"http://{{ etcd_ip_address }}:2379\""
+    line="ETCD_LISTEN_CLIENT_URLS=\"{{ etcd_url_protocol }}://{{ etcd_ip_address }}:2379\""
   notify:
     - restart etcd
 
@@ -18,9 +26,53 @@
   lineinfile:
     dest=/etc/etcd/etcd.conf
     regexp="^(\#*)ETCD_ADVERTISE_CLIENT_URLS(.*)"
-    line="ETCD_ADVERTISE_CLIENT_URLS=\"http://{{ etcd_ip_address }}:2379\""
+    line="ETCD_ADVERTISE_CLIENT_URLS=\"{{ etcd_url_protocol }}://{{ etcd_ip_address }}:2379\""
   notify:
     - restart etcd
+
+#
+# https://coreos.com/etcd/docs/latest/op-guide/security.html
+#
+
+- name: Configure etcd.conf ETCD_CERT_FILE (when TLS client auth is enabled)
+  lineinfile:
+    dest=/etc/etcd/etcd.conf
+    regexp="^(\#*)ETCD_CERT_FILE(.*)"
+    line="ETCD_CERT_FILE=\"{{ etcd_cert_file }}\""
+  notify:
+    - restart etcd
+  when: etcd_tls_client_auth == True
+
+- name: Configure etcd.conf ETCD_KEY_FILE (when TLS client auth is enabled)
+  lineinfile:
+    dest=/etc/etcd/etcd.conf
+    regexp="^(\#*)ETCD_KEY_FILE(.*)"
+    line="ETCD_KEY_FILE=\"{{ etcd_key_file }}\""
+  notify:
+    - restart etcd
+  when: etcd_tls_client_auth == True
+
+- name: Configure etcd.conf ETCD_CLIENT_CERT_AUTH (when TLS client auth is enabled)
+  lineinfile:
+    dest=/etc/etcd/etcd.conf
+    regexp="^(\#*)ETCD_CLIENT_CERT_AUTH(.*)"
+    line="ETCD_CLIENT_CERT_AUTH=\"true\""
+  notify:
+    - restart etcd
+  when: etcd_tls_client_auth == True
+
+- name: Configure etcd.conf ETCD_TRUSTED_CA_FILE (when TLS client auth is enabled)
+  lineinfile:
+    dest=/etc/etcd/etcd.conf
+    regexp="^(\#*)ETCD_TRUSTED_CA_FILE(.*)"
+    line="ETCD_TRUSTED_CA_FILE=\"{{ etcd_trusted_ca_file }}\""
+  notify:
+    - restart etcd
+  when: etcd_tls_client_auth == True
+
+#
+# Enable and start the service
+#
 
 - name: Enable etcd service
   service:

--- a/roles/tendrl-server/tasks/main.yml
+++ b/roles/tendrl-server/tasks/main.yml
@@ -1,11 +1,6 @@
 ---
 # tasks file for tendrl-server
 
-- name: Use ip address of default ipv4 network interface for etcd
-  set_fact:
-    etcd_ip_address: '{{ ansible_default_ipv4.address }}'
-  when: etcd_ip_address is undefined
-
 - name: Use ip address of default ipv4 network interface for graphite
   set_fact:
     graphite_ip_address: '{{ ansible_default_ipv4.address }}'
@@ -13,7 +8,8 @@
 
 - debug:
     msg:
-      - "Using {{ etcd_ip_address }} as etcd ip address."
+      - "Using {{ etcd_fqdn }} as etcd fqdn in tendrl config files."
+      - "Using {{ etcd_ip_address }} as etcd ip address in etcd config file."
       - "Using {{ graphite_ip_address }} as graphite ip address."
 
 - include: etcd.yml

--- a/roles/tendrl-server/tasks/main.yml
+++ b/roles/tendrl-server/tasks/main.yml
@@ -1,16 +1,11 @@
 ---
 # tasks file for tendrl-server
 
-- name: Use ip address of default ipv4 network interface for graphite
-  set_fact:
-    graphite_ip_address: '{{ ansible_default_ipv4.address }}'
-  when: graphite_ip_address is undefined
-
 - debug:
     msg:
       - "Using {{ etcd_fqdn }} as etcd fqdn in tendrl config files."
       - "Using {{ etcd_ip_address }} as etcd ip address in etcd config file."
-      - "Using {{ graphite_ip_address }} as graphite ip address."
+      - "Using {{ graphite_fqdn }} as graphite fqdn in tendrl config files."
 
 - include: etcd.yml
 - include: tendrl-node-agent.yml

--- a/roles/tendrl-server/tasks/tendrl-api.yml
+++ b/roles/tendrl-server/tasks/tendrl-api.yml
@@ -13,22 +13,6 @@
   notify:
     - restart tendrl-api
 
-- name: Configure tendrl-api etcd.yml user_name
-  replace:
-    dest: /etc/tendrl/etcd.yml
-    regexp: "^ +:user_name:.*"
-    replace: "  :user_name: ''"
-  notify:
-    - restart tendrl-api
-
-- name: Configure tendrl-api etcd.yml password
-  replace:
-    dest: /etc/tendrl/etcd.yml
-    regexp: "^ +:password:.*"
-    replace: "  :password: ''"
-  notify:
-    - restart tendrl-api
-
 - name: Configure etcd client-server authentication
   replace:
     dest: /etc/tendrl/etcd.yml

--- a/roles/tendrl-server/tasks/tendrl-api.yml
+++ b/roles/tendrl-server/tasks/tendrl-api.yml
@@ -9,7 +9,7 @@
   replace:
     dest: /etc/tendrl/etcd.yml
     regexp: "^ +:host:.*"
-    replace: "  :host: '{{ etcd_ip_address }}'"
+    replace: "  :host: '{{ etcd_fqdn }}'"
   notify:
     - restart tendrl-api
 

--- a/roles/tendrl-server/tasks/tendrl-api.yml
+++ b/roles/tendrl-server/tasks/tendrl-api.yml
@@ -29,6 +29,22 @@
   notify:
     - restart tendrl-api
 
+- name: Configure etcd client-server authentication
+  replace:
+    dest: /etc/tendrl/etcd.yml
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.line }}"
+  with_items:
+    - regexp: "^ +:etcd_ca_cert_file:.*"
+      line: "  :etcd_ca_cert_file: '{{ etcd_trusted_ca_file }}'"
+    - regexp: "^ +:etcd_cert_file:.*"
+      line: "  :etcd_cert_file: '{{ etcd_cert_file }}'"
+    - regexp: "^ +:etcd_key_file:.*"
+      line: "  :etcd_key_file: '{{ etcd_key_file }}'"
+  notify:
+    - restart tendrl-api
+  when: etcd_tls_client_auth == True
+
 # based on description from:
 # https://github.com/Tendrl/api/blob/master/docs/users.adoc#create-admin-user
 - name: Create Tendrl admin user

--- a/roles/tendrl-server/tasks/tendrl-api.yml
+++ b/roles/tendrl-server/tasks/tendrl-api.yml
@@ -35,12 +35,12 @@
     regexp: "{{ item.regexp }}"
     replace: "{{ item.line }}"
   with_items:
-    - regexp: "^ +:etcd_ca_cert_file:.*"
-      line: "  :etcd_ca_cert_file: '{{ etcd_trusted_ca_file }}'"
-    - regexp: "^ +:etcd_cert_file:.*"
-      line: "  :etcd_cert_file: '{{ etcd_cert_file }}'"
-    - regexp: "^ +:etcd_key_file:.*"
-      line: "  :etcd_key_file: '{{ etcd_key_file }}'"
+    - regexp: "^ +:ca_cert_file:.*"
+      line: "  :ca_cert_file: '{{ etcd_trusted_ca_file }}'"
+    - regexp: "^ +:client_cert_file:.*"
+      line: "  :client_cert_file: '{{ etcd_cert_file }}'"
+    - regexp: "^ +:client_key_file:.*"
+      line: "  :client_key_file: '{{ etcd_key_file }}'"
   notify:
     - restart tendrl-api
   when: etcd_tls_client_auth == True

--- a/roles/tendrl-server/tasks/tendrl-monitoring-integration.yml
+++ b/roles/tendrl-server/tasks/tendrl-monitoring-integration.yml
@@ -87,6 +87,22 @@
   notify:
     - restart tendrl-monitoring-integration
 
+- name: Configure etcd client-server authentication
+  lineinfile:
+    dest: /etc/tendrl/monitoring-integration/monitoring-integration.conf.yaml
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  with_items:
+    - regexp: '^#? *etcd_ca_cert_file:.*'
+      line: "etcd_ca_cert_file: {{ etcd_trusted_ca_file }}"
+    - regexp: '^#? *etcd_cert_file:.*'
+      line: "etcd_cert_file: {{ etcd_cert_file }}"
+    - regexp: '^#? *etcd_key_file:.*'
+      line: "etcd_key_file: {{ etcd_key_file }}"
+  notify:
+    - restart tendrl-monitoring-integration
+  when: etcd_tls_client_auth == True
+
 - name: Configure grafana admin password in monitoring-integration.conf.yaml
   lineinfile:
     dest: /etc/tendrl/monitoring-integration/monitoring-integration.conf.yaml

--- a/roles/tendrl-server/tasks/tendrl-monitoring-integration.yml
+++ b/roles/tendrl-server/tasks/tendrl-monitoring-integration.yml
@@ -81,7 +81,7 @@
     line={{ item.line }}
   with_items:
     - regexp: '^datasource_host:.*'
-      line: "datasource_host: {{ graphite_ip_address }}"
+      line: "datasource_host: {{ graphite_fqdn }}"
     - regexp: '^etcd_connection:.*'
       line: "etcd_connection: {{ etcd_fqdn }}"
   notify:

--- a/roles/tendrl-server/tasks/tendrl-monitoring-integration.yml
+++ b/roles/tendrl-server/tasks/tendrl-monitoring-integration.yml
@@ -83,7 +83,7 @@
     - regexp: '^datasource_host:.*'
       line: "datasource_host: {{ graphite_ip_address }}"
     - regexp: '^etcd_connection:.*'
-      line: "etcd_connection: {{ etcd_ip_address }}"
+      line: "etcd_connection: {{ etcd_fqdn }}"
   notify:
     - restart tendrl-monitoring-integration
 

--- a/roles/tendrl-server/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-server/tasks/tendrl-node-agent.yml
@@ -18,6 +18,22 @@
   notify:
     - restart tendrl-node-agent
 
+- name: Configure etcd client-server authentication
+  lineinfile:
+    dest: /etc/tendrl/node-agent/node-agent.conf.yaml
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  with_items:
+    - regexp: '^#? *etcd_ca_cert_file:.*'
+      line: "etcd_ca_cert_file: {{ etcd_trusted_ca_file }}"
+    - regexp: '^#? *etcd_cert_file:.*'
+      line: "etcd_cert_file: {{ etcd_cert_file }}"
+    - regexp: '^#? *etcd_key_file:.*'
+      line: "etcd_key_file: {{ etcd_key_file }}"
+  notify:
+    - restart tendrl-node-agent
+  when: etcd_tls_client_auth == True
+
 - name: Configure graphite_port in node-agent.conf.yaml (only when needed)
   lineinfile:
     dest: /etc/tendrl/node-agent/node-agent.conf.yaml

--- a/roles/tendrl-server/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-server/tasks/tendrl-node-agent.yml
@@ -14,7 +14,7 @@
     - regexp: '^etcd_connection:.*'
       line: "etcd_connection: {{ etcd_fqdn }}"
     - regexp: '^graphite_host:.*'
-      line: "graphite_host: {{ graphite_ip_address }}"
+      line: "graphite_host: {{ graphite_fqdn }}"
   notify:
     - restart tendrl-node-agent
 

--- a/roles/tendrl-server/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-server/tasks/tendrl-node-agent.yml
@@ -12,7 +12,7 @@
     line: "{{ item.line }}"
   with_items:
     - regexp: '^etcd_connection:.*'
-      line: "etcd_connection: {{ etcd_ip_address }}"
+      line: "etcd_connection: {{ etcd_fqdn }}"
     - regexp: '^graphite_host:.*'
       line: "graphite_host: {{ graphite_ip_address }}"
   notify:

--- a/roles/tendrl-server/tasks/tendrl-notifier.yml
+++ b/roles/tendrl-server/tasks/tendrl-notifier.yml
@@ -16,6 +16,22 @@
   notify:
     - restart tendrl-notifier
 
+- name: Configure etcd client-server authentication
+  lineinfile:
+    dest: /etc/tendrl/notifier/notifier.conf.yaml
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  with_items:
+    - regexp: '^#? *etcd_ca_cert_file:.*'
+      line: "etcd_ca_cert_file: {{ etcd_trusted_ca_file }}"
+    - regexp: '^#? *etcd_cert_file:.*'
+      line: "etcd_cert_file: {{ etcd_cert_file }}"
+    - regexp: '^#? *etcd_key_file:.*'
+      line: "etcd_key_file: {{ etcd_key_file }}"
+  notify:
+    - restart tendrl-notifier
+  when: etcd_tls_client_auth == True
+
 - name: Configure email source (done only when email config is provided)
   lineinfile:
     dest: /etc/tendrl/notifier/email.conf.yaml

--- a/roles/tendrl-server/tasks/tendrl-notifier.yml
+++ b/roles/tendrl-server/tasks/tendrl-notifier.yml
@@ -12,7 +12,7 @@
     line: "{{ item.line }}"
   with_items:
     - regexp: '^etcd_connection:.*'
-      line: "etcd_connection: {{ etcd_ip_address }}"
+      line: "etcd_connection: {{ etcd_fqdn }}"
   notify:
     - restart tendrl-notifier
 

--- a/roles/tendrl-storage-node/README.md
+++ b/roles/tendrl-storage-node/README.md
@@ -14,7 +14,7 @@ dependencies) are already available on the machine.
 Role Variables
 --------------
 
- *  Variable `etcd_ip_address` needs to be set to ipv4 adress of etcd instance.
+ *  Variable `etcd_fqdn` needs to be set to fqdn of etcd instance.
     Specifying this variable is mandatory as there is no default value.
 
  *  Variable `graphite_ip_address` needs to be set to ipv4 adress of graphite

--- a/roles/tendrl-storage-node/README.md
+++ b/roles/tendrl-storage-node/README.md
@@ -21,6 +21,38 @@ Role Variables
     instance. Specifying this variable is mandatory as there is no default
     value.
 
+ *  When `etcd_tls_client_auth` is set to False (which is the default state),
+    tendrl components will be configured to work with etcd without any
+    authentication (default etcd behavior).
+
+    When `etcd_tls_client_auth` is True, all Tendrl components will be
+    reconfigured to use client to server authentication with HTTPS client
+    certificates.
+
+    The placement of tls cert files can be tweaked via ansible variables
+    explained below.
+
+    For more details, see README file of tendrl server ansible role.
+
+ *  Variable `etcd_cert_file` specifies full filepath of `ETCD_CERT_FILE` etcd
+    option. The default value is `/etc/pki/tls/certs/etcd.crt`.
+
+    For more details, see [Etcd Security
+    model](https://coreos.com/etcd/docs/latest/op-guide/security.html)
+
+ *  Variable `etcd_key_file` specifies full filepath of `ETCD_KEY_FILE` etcd
+    option. The default value is `/etc/pki/tls/private/etcd.key`.
+
+    For more details, see [Etcd Security
+    model](https://coreos.com/etcd/docs/latest/op-guide/security.html)
+
+ *  Variable `etcd_trusted_ca_file` specifies full filepath of
+    `ETCD_TRUSTED_CA_FILE` etcd option. The default value is
+    `/etc/pki/tls/certs/ca-etcd.crt`.
+
+    For more details, see [Etcd Security
+    model](https://coreos.com/etcd/docs/latest/op-guide/security.html)
+
 Note that values specified in variables of this role need to match variables
 of *Tendrl Server* role.
 

--- a/roles/tendrl-storage-node/README.md
+++ b/roles/tendrl-storage-node/README.md
@@ -17,7 +17,7 @@ Role Variables
  *  Variable `etcd_fqdn` needs to be set to fqdn of etcd instance.
     Specifying this variable is mandatory as there is no default value.
 
- *  Variable `graphite_ip_address` needs to be set to ipv4 adress of graphite
+ *  Variable `graphite_fqdn` needs to be set to fqdn of graphite
     instance. Specifying this variable is mandatory as there is no default
     value.
 

--- a/roles/tendrl-storage-node/defaults/main.yml
+++ b/roles/tendrl-storage-node/defaults/main.yml
@@ -1,2 +1,8 @@
 ---
 # defaults file for tendrl-node
+etcd_tls_client_auth: False
+# default paths for etcd ssl files based on
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-using_openssl
+etcd_cert_file: "/etc/pki/tls/certs/etcd.crt"
+etcd_key_file: "/etc/pki/tls/private/etcd.key"
+etcd_trusted_ca_file: "/etc/pki/tls/certs/ca-etcd.crt"

--- a/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
@@ -18,6 +18,22 @@
   notify:
     - restart tendrl-node-agent
 
+- name: Configure etcd client-server authentication
+  lineinfile:
+    dest: /etc/tendrl/node-agent/node-agent.conf.yaml
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  with_items:
+    - regexp: '^#? *etcd_ca_cert_file:.*'
+      line: "etcd_ca_cert_file: {{ etcd_trusted_ca_file }}"
+    - regexp: '^#? *etcd_cert_file:.*'
+      line: "etcd_cert_file: {{ etcd_cert_file }}"
+    - regexp: '^#? *etcd_key_file:.*'
+      line: "etcd_key_file: {{ etcd_key_file }}"
+  notify:
+    - restart tendrl-node-agent
+  when: etcd_tls_client_auth == True
+
 - name: Enable tendrl-node-agent service
   service:
     name=tendrl-node-agent

--- a/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
@@ -14,7 +14,7 @@
     - regexp: '^etcd_connection:.*'
       line: "etcd_connection: {{ etcd_fqdn }}"
     - regexp: '^graphite_host:.*'
-      line: "graphite_host: {{ graphite_ip_address }}"
+      line: "graphite_host: {{ graphite_fqdn }}"
   notify:
     - restart tendrl-node-agent
 

--- a/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
@@ -12,7 +12,7 @@
     line: "{{ item.line }}"
   with_items:
     - regexp: '^etcd_connection:.*'
-      line: "etcd_connection: {{ etcd_ip_address }}"
+      line: "etcd_connection: {{ etcd_fqdn }}"
     - regexp: '^graphite_host:.*'
       line: "graphite_host: {{ graphite_ip_address }}"
   notify:

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -49,13 +49,15 @@
   # playbooks in this directory as well)
   # become: yes
   vars:
-    # You need to specify ip address where etcd will be listening, either by:
-    # - ip adress value (based on prior knowledge of your infrastructure)
-    # etcd_ip_address: '192.0.2.2'
-    # - using ansible facts: asking for ipv4 address of interface eth1
-    # etcd_ip_address: "{{ ansible_eth1.ipv4.address }}"
-    # - using ansible facts: asking for ipv4 address of default interface
-    etcd_ip_address: "{{ ansible_default_ipv4.address }}"
+    # You need to specify fqdn where etcd will be listening, either by
+    # value based on prior knowledge of your infrastructure:
+    # etcd_fqdn: 'tendrl.example.com'
+    # or using ansible facts: fqdn of tendrl-server as detected by ansible:
+    etcd_fqdn: "{{ ansible_fqdn }}"
+    # Moreover you need to use ip address of interface where etcd will be
+    # listening, to configure etcd itself.
+    etcd_ip_address: "{{ lookup('dig', ansible_fqdn) }}"
+
     # IP address of graphite (carbon-cache service in particular) which will
     # be used in tendrl-node-agent config file (this value doesn't reconfigure
     # graphite).
@@ -67,6 +69,7 @@
     - name: Check that variables are defined properly (just to make this clear)
       assert:
         that:
+          - etcd_fqdn is defined
           - etcd_ip_address is defined
           - graphite_ip_address is defined
   roles:
@@ -79,7 +82,7 @@
   # become: yes
   vars:
     # make sure this value is the same
-    etcd_ip_address: "{{ hostvars[groups['tendrl-server'][0]].ansible_default_ipv4.address }}"
+    etcd_fqdn: "{{ hostvars[groups['tendrl-server'][0]].ansible_fqdn }}"
     graphite_ip_address: "{{ hostvars[groups['tendrl-server'][0]].ansible_default_ipv4.address }}"
   roles:
     - tendrl-copr

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -58,20 +58,20 @@
     # listening, to configure etcd itself.
     etcd_ip_address: "{{ lookup('dig', ansible_fqdn) }}"
 
-    # IP address of graphite (carbon-cache service in particular) which will
-    # be used in tendrl-node-agent config file (this value doesn't reconfigure
+    # fqdn of graphite instance (carbon-cache service in particular) which will
+    # be used in tendrl config files (this value doesn't reconfigure
     # graphite).
-    # Note that a safe default value for ip address of graphite is the same one
+    # Note that a safe default value for fqdn of graphite is the same one
     # we use for etcd here (tendrl-server role places both services on the same
     # machine).
-    graphite_ip_address: "{{ etcd_ip_address }}"
+    graphite_fqdn: "{{ etcd_fqdn }}"
   pre_tasks:
     - name: Check that variables are defined properly (just to make this clear)
       assert:
         that:
           - etcd_fqdn is defined
           - etcd_ip_address is defined
-          - graphite_ip_address is defined
+          - graphite_fqdn is defined
   roles:
     - grafana-repo
     - tendrl-copr
@@ -83,7 +83,7 @@
   vars:
     # make sure this value is the same
     etcd_fqdn: "{{ hostvars[groups['tendrl-server'][0]].ansible_fqdn }}"
-    graphite_ip_address: "{{ hostvars[groups['tendrl-server'][0]].ansible_default_ipv4.address }}"
+    graphite_fqdn: "{{ hostvars[groups['tendrl-server'][0]].ansible_fqdn }}"
   roles:
     - tendrl-copr
     - tendrl-storage-node


### PR DESCRIPTION
This is setup for etcd client-server tls auth.

Implements https://github.com/Tendrl/tendrl-ansible/issues/42 (see all the details there).

It's possible to:

* install tendrl without etcd client-server tls auth enabled (the default)
* install tendrl with etcd client-server tls auth enabled
* install tendrl without etcd client-server tls auth enabled, but enable it later by reruning tendrl-ansible with updated variables

It's not possible to disable this when it was once enabled (there are no requirements for that use case).

Also note that issuing and deployment of tls client certificates and keys is out of scope of this feature. Admin needs to do this before running tendrl-ansible with etcd client-server tls auth enabled.