### PR TITLE
snmp configuration

### DIFF
--- a/roles/tendrl-server/README.md
+++ b/roles/tendrl-server/README.md
@@ -175,6 +175,9 @@ Role Variables
     `/etc/tendrl/notifier/snmp.conf.yaml` on tendrl server and restart
     tendrl-notifier service.
 
+    For more details (including supported versions of snmp protocol and example
+    configuration of snmp endpoint), see Tendrl Installation Guide.
+
 License
 -------
 

--- a/roles/tendrl-server/README.md
+++ b/roles/tendrl-server/README.md
@@ -163,6 +163,18 @@ Role Variables
     For more details about email configuration of tendrl-notifier, see the
     Tendrl documentation.
 
+ *  When `tendrl_notifier_snmp_conf_file` variable is undefined, tendrl
+    notifier will not send any snmp notifications, which is the default state.
+
+    To configure snmp notifications, create new `snmp.conf.yaml` file
+    based on default `/etc/tendrl/notifier/snmp.conf.yaml` file from
+    tendrl-notifier package, and set it's local path (on ansible control
+    machine) as a value of `tendrl_notifier_snmp_conf_file` variable.
+
+    Based on that, tendrl-ansible will then copy the local file into
+    `/etc/tendrl/notifier/snmp.conf.yaml` on tendrl server and restart
+    tendrl-notifier service.
+
 License
 -------
 

--- a/roles/tendrl-server/tasks/tendrl-notifier.yml
+++ b/roles/tendrl-server/tasks/tendrl-notifier.yml
@@ -70,6 +70,20 @@
   notify:
     - restart tendrl-notifier
 
+#
+# snmp notifications
+#
+
+- name: Configure snmp (done only when snmp config is provided)
+  copy:
+    src: "{{ tendrl_notifier_snmp_conf_file }}"
+    dest: /etc/tendrl/notifier/snmp.conf.yaml
+    backup: yes
+    mode: 0640
+  when: tendrl_notifier_snmp_conf_file is defined
+  notify:
+    - restart tendrl-notifier
+
 - name: Enable tendrl-notifier service
   service:
     name=tendrl-notifier

--- a/roles/tendrl-server/tasks/tendrl-notifier.yml
+++ b/roles/tendrl-server/tasks/tendrl-notifier.yml
@@ -32,6 +32,10 @@
     - restart tendrl-notifier
   when: etcd_tls_client_auth|bool == True
 
+#
+# email notifications
+#
+
 - name: Configure email source (done only when email config is provided)
   lineinfile:
     dest: /etc/tendrl/notifier/email.conf.yaml


### PR DESCRIPTION
Based on [current upstream installation guide](https://github.com/Tendrl/documentation/wiki/Tendrl-release-latest/_compare/94995e86b304cdafbdc5d0e555b99ab0684d1c30...67c966d57bbaade16b207a990b83c91e1422f433), this pull request adds a possibility to setup snmp notifications.

This is done via ansible copy module, which will copy local file with snmp configuration into a proper place on tendrl server.

I don't edit the config file directly as I do in other cases, because the snmp yaml file has a multi level structure, and without standardized ansible module for editing yaml files, it's not possible to implemen this in a reliable way. Moreover one needs to configure receiving machine as well, which is out of      
scope for tendrl-ansible to do.

tendrl-bug-id: https://github.com/Tendrl/tendrl-ansible/issues/59