### PR TITLE
Reload rsyslog after installing node-agent

### DIFF
--- a/roles/tendrl-server/handlers/main.yml
+++ b/roles/tendrl-server/handlers/main.yml
@@ -16,6 +16,11 @@
     name=httpd
     state=restarted
 
+- name: restart rsyslog
+  service:
+    name=rsyslog
+    state=restarted
+
 - name: restart tendrl-node-agent
   service:
     name=tendrl-node-agent

--- a/roles/tendrl-server/tasks/main.yml
+++ b/roles/tendrl-server/tasks/main.yml
@@ -23,6 +23,7 @@
     state=latest
 
 - include: etcd.yml
+- include: rsyslog.yml
 - include: tendrl-node-agent.yml
 - include: tendrl-api.yml
 - include: tendrl-ui.yml

--- a/roles/tendrl-server/tasks/rsyslog.yml
+++ b/roles/tendrl-server/tasks/rsyslog.yml
@@ -1,0 +1,7 @@
+---
+
+- name: ensure rsyslog is enabled and running SERVER-NGCHECKINGCHECKINGCHECKINGCHECKINGCHECKING
+  service:
+    name=rsyslog
+    state=started
+    enabled=yes

--- a/roles/tendrl-server/tasks/rsyslog.yml
+++ b/roles/tendrl-server/tasks/rsyslog.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: ensure rsyslog is enabled and running SERVER-NGCHECKINGCHECKINGCHECKINGCHECKINGCHECKING
+- name: ensure rsyslog is enabled and running
   service:
     name=rsyslog
     state=started

--- a/roles/tendrl-server/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-server/tasks/tendrl-node-agent.yml
@@ -55,4 +55,6 @@
     name=tendrl-node-agent
     state=started
   notify:
+   # workaround for case when a new tendrl-node-agent package is installed
+   # during "Update all installed packages" task
    - restart rsyslog

--- a/roles/tendrl-server/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-server/tasks/tendrl-node-agent.yml
@@ -4,6 +4,8 @@
   yum:
     name=tendrl-node-agent
     state=latest
+  notify:
+   - restart rsyslog
 
 - name: Configure etcd and graphite ip addr in node-agent.conf.yaml
   lineinfile:
@@ -52,3 +54,5 @@
   service:
     name=tendrl-node-agent
     state=started
+  notify:
+   - restart rsyslog

--- a/roles/tendrl-storage-node/handlers/main.yml
+++ b/roles/tendrl-storage-node/handlers/main.yml
@@ -5,3 +5,8 @@
   service:
     name=tendrl-node-agent
     state=restarted
+
+- name: reload rsyslog
+  service:
+    name=rsyslogd
+    state=reloaded

--- a/roles/tendrl-storage-node/handlers/main.yml
+++ b/roles/tendrl-storage-node/handlers/main.yml
@@ -6,7 +6,7 @@
     name=tendrl-node-agent
     state=restarted
 
-- name: reload rsyslog
+- name: restart rsyslog
   service:
-    name=rsyslogd
-    state=reloaded
+    name=rsyslog
+    state=restarted

--- a/roles/tendrl-storage-node/tasks/main.yml
+++ b/roles/tendrl-storage-node/tasks/main.yml
@@ -21,5 +21,5 @@
     name=tendrl-collectd-selinux
     state=latest
 
-- include: tendrl-node-agent.yml
 - include: rsyslog.yml
+- include: tendrl-node-agent.yml

--- a/roles/tendrl-storage-node/tasks/main.yml
+++ b/roles/tendrl-storage-node/tasks/main.yml
@@ -22,3 +22,4 @@
     state=latest
 
 - include: tendrl-node-agent.yml
+- include: rsyslog.yml

--- a/roles/tendrl-storage-node/tasks/rsyslog.yml
+++ b/roles/tendrl-storage-node/tasks/rsyslog.yml
@@ -1,6 +1,7 @@
 ---
 
-- name: ensure rsyslog is running
+- name: ensure rsyslog is enabled and running
   service:
-    name=rsyslogd
+    name=rsyslog
     state=started
+    enabled=yes

--- a/roles/tendrl-storage-node/tasks/rsyslog.yml
+++ b/roles/tendrl-storage-node/tasks/rsyslog.yml
@@ -1,0 +1,6 @@
+---
+
+- name: ensure rsyslog is running
+  service:
+    name=rsyslogd
+    state=started

--- a/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
@@ -17,7 +17,6 @@
       line: "graphite_host: {{ graphite_fqdn }}"
   notify:
     - restart tendrl-node-agent
-  notify:
     - reload rsyslog
 
 - name: Configure etcd client-server authentication
@@ -35,8 +34,6 @@
   notify:
     - restart tendrl-node-agent
   when: etcd_tls_client_auth|bool == True
-  notify:
-    - reload rsyslog
 
 - name: Enable tendrl-node-agent service
   service:

--- a/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
@@ -4,6 +4,8 @@
   yum:
     name=tendrl-node-agent
     state=latest
+  notify:
+   - restart rsyslog
 
 - name: Configure etcd and graphite ip addr in node-agent.conf.yaml
   lineinfile:
@@ -17,7 +19,6 @@
       line: "graphite_host: {{ graphite_fqdn }}"
   notify:
     - restart tendrl-node-agent
-    - reload rsyslog
 
 - name: Configure etcd client-server authentication
   lineinfile:
@@ -44,3 +45,5 @@
   service:
     name=tendrl-node-agent
     state=started
+  notify:
+   - restart rsyslog

--- a/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
@@ -46,4 +46,6 @@
     name=tendrl-node-agent
     state=started
   notify:
+   # workaround for case when a new tendrl-node-agent package is installed
+   # during "Update all installed packages" task
    - restart rsyslog

--- a/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-storage-node/tasks/tendrl-node-agent.yml
@@ -17,6 +17,8 @@
       line: "graphite_host: {{ graphite_fqdn }}"
   notify:
     - restart tendrl-node-agent
+  notify:
+    - reload rsyslog
 
 - name: Configure etcd client-server authentication
   lineinfile:
@@ -33,6 +35,8 @@
   notify:
     - restart tendrl-node-agent
   when: etcd_tls_client_auth|bool == True
+  notify:
+    - reload rsyslog
 
 - name: Enable tendrl-node-agent service
   service:


### PR DESCRIPTION
The patch does the following things after installing node agent.
 * Start rsyslogd service if its not started
 * Reload rsyslogd after tendrl-node-agent service restart

tendrl-bug-id: Tendrl/tendrl-ansible#683
Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>