### PR TITLE
don't change SELinux mode (drop selinux_mode var.)

### DIFF
--- a/roles/tendrl-server/README.md
+++ b/roles/tendrl-server/README.md
@@ -31,10 +31,6 @@ If you want to be able to provision Ceph clusters with Tendrl, use role
 Role Variables
 --------------
 
- *  Variable `selinux_mode` specifies which SELinux mode of `targeted` policy
-    should be enabled: either `enforcing` or `permissive` (which is the
-    default).
-
  *  Variable `etcd_ip_address` is mandatory, when you let this variable
     undefined, installation will fail.
 

--- a/roles/tendrl-server/defaults/main.yml
+++ b/roles/tendrl-server/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-# selinux mode (system wide, see man sestatus)
-selinux_mode: "permissive"
 # defaults file for tendrl-server
 tendrl_notifier_email_smtp_port: 25
 etcd_tls_client_auth: False

--- a/roles/tendrl-server/tasks/main.yml
+++ b/roles/tendrl-server/tasks/main.yml
@@ -7,16 +7,6 @@
       - "Using {{ etcd_ip_address }} as etcd ip address in etcd config file."
       - "Using {{ graphite_fqdn }} as graphite fqdn in tendrl config files."
 
-- name: Make sure that libselinux-python is installed
-  yum:
-    name: libselinux-python
-    state: latest
-
-- name: Switch SELinux targeted policy to expected mode
-  selinux:
-    policy: targeted
-    state: "{{ selinux_mode }}"
-
 - name: Install tendrl-selinux
   yum:
     name=tendrl-selinux

--- a/roles/tendrl-storage-node/README.md
+++ b/roles/tendrl-storage-node/README.md
@@ -14,10 +14,6 @@ dependencies) are already available on the machine.
 Role Variables
 --------------
 
- *  Variable `selinux_mode` specifies which SELinux mode of `targeted` policy
-    should be enabled: either `enforcing` or `permissive` (which is the
-    default).
-
  *  Variable `etcd_fqdn` needs to be set to fqdn of etcd instance.
     Specifying this variable is mandatory as there is no default value.
 

--- a/roles/tendrl-storage-node/defaults/main.yml
+++ b/roles/tendrl-storage-node/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-# selinux mode (system wide, see man sestatus)
-selinux_mode: "permissive"
 # defaults file for tendrl-node
 etcd_tls_client_auth: False
 # default paths for etcd ssl files based on

--- a/roles/tendrl-storage-node/tasks/main.yml
+++ b/roles/tendrl-storage-node/tasks/main.yml
@@ -1,16 +1,6 @@
 ---
 # tasks file for tendrl-node
 
-- name: Make sure that libselinux-python is installed
-  yum:
-    name: libselinux-python
-    state: latest
-
-- name: Switch SELinux targeted policy to expected mode
-  selinux:
-    policy: targeted
-    state: "{{ selinux_mode }}"
-
 - name: Install tendrl-selinux
   yum:
     name=tendrl-selinux


### PR DESCRIPTION
Since it's no longer necessary to change SELinux mode to permissive
install Tendrl, removing code related to setting SELinux mode from
tendrl-ansible.

tendrl-bug-id: https://github.com/Tendrl/tendrl-ansible/issues/66