### PR TITLE
update prechecks for both poc and prod deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,14 @@ tendrl.example.com
    In case of any problems, you need to fix it
    before going on. If you are not sure what's wrong, consult documentation of
    ansible and/or ssh.
-6) Run `$ ansible-playbook -i inventory_file site.yml`
-7) Log in to your tendrl server at ``http://ip.of.tendrl.server`` with
+6) Run `$ ansible-playbook -i inventory_file prechecks.yml` to verify that
+   your machines meet expected requirements for **production deployment** (see
+   content of the `prechecks.yml` playbook file for details).
+   For **proof of concept deployments**, you can avoid checking of stringent
+   production requirements using `production` tag:
+   `$ ansible-playbook -i inventory_file prechecks.yml --skip-tags "production"`
+7) Run `$ ansible-playbook -i inventory_file site.yml`
+8) Log in to your tendrl server at ``http://ip.of.tendrl.server`` with
    ``admin`` user and the default password ``adminuser``.
 
 ## Setup with Vagrant using libvirt provider

--- a/README.rpm.md
+++ b/README.rpm.md
@@ -18,14 +18,6 @@ you can find all details about it's usage.
 To understand how all this fits together, see sample ansible playbook file
 `/usr/share/doc/tendrl-ansible-VERSION/site.yml.sample`.
 
-Also note that the sample playbook includes
-`/usr/share/doc/tendrl-ansible-VERSION/prechecks.yml`, which you can run
-directly as well to check if minimal requirements and setup for Tendrl are
-satisfied. Any problem with the pre checks will make sample site.yml file
-immediately fail, pointing you to a particular requirement or problem with
-configuration before the installation itself (preventing you to spare time
-with unnecessary debugging after installation).
-
 ## Basic setup
 
 1)  Install tendrl-ansible:
@@ -67,6 +59,26 @@ with unnecessary debugging after installation).
     You should see ansible to show `"pong"` message for all machines.
     In case of any problems, you need to fix it before going on. If you are not
     sure what's wrong, consult documentation of ansible and/or ssh.
+
+5)  Now you can run prechecks playbook to verify if minimal requirements and
+    setup for Tendrl are satisfied. Any problem with the pre checks will make
+    the playbook run fail immediately, pointing you to a particular
+    requirement or problem with configuration before the installation itself
+    (preventing you to spend time with unnecessary debugging after
+    installation).
+
+    For **production deployment**, run the full check:
+
+    ```
+    $ ansible-playbook -i inventory_file /usr/share/doc/tendrl-ansible-VERSION/prechecks.yml
+    ```
+
+    While for **proof of concept deployments**, you can avoid checking of
+    stringent production requirements using `production` tag:
+
+    ```
+    $ ansible-playbook -i inventory_file /usr/share/doc/tendrl-ansible-VERSION/prechecks.yml --skip-tags "production"
+    ```
 
 5)  Then we are ready to run ansible to install Tendrl:
 

--- a/prechecks.yml
+++ b/prechecks.yml
@@ -1,6 +1,7 @@
 ---
 # A simple playbook with Tendrl installation pre checks as listed in:
 # https://tendrl.atlassian.net/browse/TEN-257
+# This playbook doesn't modify machines in any way.
 
 - hosts: localhost
   connection: local
@@ -22,6 +23,8 @@
 #
 
 - hosts: tendrl-server
+  tags:
+    - production
   tasks:
     # Based on:
     #

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -14,12 +14,6 @@
 # doesn't care how you group your servers in ansible inventory.
 
 #
-# Validation of prerequisities for Tendrl, doesn't modify machines in any way.
-#
-
-- include: prechecks.yml
-
-#
 # Workarounds required to run before the installation.
 #
 


### PR DESCRIPTION
Remove include of precheck playbook from site plabyook example and
add ansible tag for production checks so that these can be skipped
for poc deployments.

Note that **this pull request is concerned with change of approach only**, any particular details (including whether or how should we check fqdn names or particular values of memory/cpu we require in the playbook https://github.com/Tendrl/tendrl-ansible/issues/65) will be addressed in a separate pull request.

resolves: https://github.com/Tendrl/tendrl-ansible/issues/73