### PR TITLE
grafana-repo role: retry yum makecache when fails

### DIFF
--- a/roles/tendrl-ansible.grafana-repo/tasks/main.yml
+++ b/roles/tendrl-ansible.grafana-repo/tasks/main.yml
@@ -32,3 +32,7 @@
 - name: "WORKAROUND for issues with grafana repo: make yum cache"
   command: "yum makecache -y --disablerepo='*' --enablerepo='grafana'"
   when: rpm_key_packagecloud.changed
+  register: task_result
+  until: task_result|success
+  retries: 5
+  delay: 5


### PR DESCRIPTION
- avoiding "[Errno 14] HTTPS Error 302 - Found" error via relaunching
  yum makecache command in case of failure
- fixes https://github.com/Tendrl/tendrl-ansible/issues/87