### PR TITLE
rename ansible groups to get rid of dash there

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,17 +147,17 @@ tendrl-ansible:
 
 2)  Create [Ansible inventory
     file](https://docs.ansible.com/ansible/latest/intro_inventory.html) with
-    groups for `tendrl-server` and `gluster-servers`. Here is an example of
+    groups for `tendrl_server` and `gluster_servers`. Here is an example of
     inventory file for 4 node cluster with Gluster:
 
     ```
-    [gluster-servers]
+    [gluster_servers]
     gl1.example.com
     gl2.example.com
     gl3.example.com
     gl4.example.com
 
-    [tendrl-server]
+    [tendrl_server]
     tendrl.example.com
     ```
 
@@ -333,7 +333,7 @@ fits into Tendrl cluster expand operation.
 
 2)  When Gluster is aware of new servers (you see them in output of `gluster
     pool list` command), you add the new servers into ansible inventory file
-    (into group `gluster-servers`) which you used during installation of
+    (into group `gluster_servers`) which you used during installation of
     Tendrl.
 
     Note that it's important to **add new servers into the same inventory file

--- a/prechecks.yml
+++ b/prechecks.yml
@@ -29,7 +29,7 @@
 # Check requirements for *Tendrl Server* only
 #
 
-- hosts: tendrl-server
+- hosts: tendrl_server
   tags:
     - production
   tasks:

--- a/site.yml
+++ b/site.yml
@@ -2,7 +2,7 @@
 # This Ansible playbook to install Tendrl, automating steps from upstream
 # *Tendrl Package Installation Reference* wiki page.
 
-- hosts: tendrl-server
+- hosts: tendrl_server
   user: root
   pre_tasks:
     - name: Check that mandatory variables are defined
@@ -19,7 +19,7 @@
     - tendrl-ansible.tendrl-copr
     - tendrl-ansible.tendrl-server
 
-- hosts: gluster-servers
+- hosts: gluster_servers
   user: root
   pre_tasks:
     - name: Check that mandatory variables are defined


### PR DESCRIPTION
This is a proposal to avoid possible problem in the future, but it introduces
incompatible change.

According to (already closed) issue ansible/ansible#30624, having group
name with a dash could be problematic when:

* one uses expression like groups.tendrl-server in custom playbook
  reusing inventory file from tendrl-ansible
* validation of ansible group name is reintroduced in ansible 2.5 or
  later

To prevent this kind of problems in the future, this commit replaces
dash with underscore in ansible group names.

tendrl-bug-id: https://github.com/Tendrl/tendrl-ansible/issues/85