### PR TITLE
set user to root in tendrl_server checks

### DIFF
--- a/prechecks.yml
+++ b/prechecks.yml
@@ -32,6 +32,8 @@
 - hosts: tendrl_server
   tags:
     - production
+  user: root
+  # become: yes
   tasks:
 
     # Based on Tendrl Server System Requirements


### PR DESCRIPTION
add `user: root` to tendrl_server checks

fixing https://github.com/Tendrl/tendrl-ansible/issues/113