### PR TITLE
Update the minimum memory requirement

### DIFF
--- a/prechecks.yml
+++ b/prechecks.yml
@@ -39,7 +39,7 @@
     - name: Assert that hw requirements are met
       assert:
         that:
-          - ansible_memtotal_mb >= 16000
+          - ansible_memtotal_mb >= 3700
           - ansible_processor_vcpus >= 4
 
     - name: Check if /var/lib/etcd is a mountpoint


### PR DESCRIPTION
Update the minimum memory requirement to run tendrl server to 4 GB
fixing Tendrl/tendrl-ansible/issues/117