### PR TITLE
Get rid of a warning during a check

### DIFF
--- a/roles/tendrl-ansible.tendrl-server/tasks/firewalld-check.yml
+++ b/roles/tendrl-ansible.tendrl-server/tasks/firewalld-check.yml
@@ -2,6 +2,8 @@
 
 - name: Check if firewalld is installed
   command: rpm -q firewalld
+  args:
+    warn: False
   register: rpm_q_firewalld
   changed_when: False
   failed_when: rpm_q_firewalld.rc > 1


### PR DESCRIPTION
Get rid of the warning about yum or dnf modules when checking if firewalld is installed.

Fixing: https://github.com/Tendrl/tendrl-ansible/issues/112