### PR TITLE
Add etcd files checks

### DIFF
--- a/roles/tendrl-ansible.tendrl-server/tasks/etcd-tls-client-auth-check.yml
+++ b/roles/tendrl-ansible.tendrl-server/tasks/etcd-tls-client-auth-check.yml
@@ -19,25 +19,25 @@
   assert:
     that:
       - etcd_crt.stat.exists == True
-    msg:
-      - "File specified in etcd_cert_file doesn't exist on remote machine."
-      - "Please specify path to etcd certificate file in the variable
-and rerun the playbook."
+    msg: >
+      File specified in etcd_cert_file doesn't exist on remote machine.
+      Please specify path to etcd certificate file in the variable and rerun
+      the playbook.
 
 - name: Check that file specified in etcd_key_file actually exists
   assert:
     that:
       - etcd_key.stat.exists == True
-    msg:
-      - "File specified in etcd_key_file doesn't exist on remote machine."
-      - "Please specify path to etcd key file in the variable
-and rerun the playbook."
+    msg: >
+      File specified in etcd_key_file doesn't exist on remote machine.
+      Please specify path to etcd key file in the variable and rerun the
+      playbook.
 
 - name: Check that file specified in etcd_trusted_ca_file actually exists
   assert:
     that:
       - etcd_trusted_ca_file.stat.exists == True
-    msg:
-      - "File specified in etcd_trusted_ca_file doesn't exist on remote machine."
-      - "Please specify path to trusted certificate authority in the variable
-and rerun the playbook."
+    msg: >
+      File specified in etcd_trusted_ca_file doesn't exist on remote machine.
+      Please specify path to trusted certificate authority in the variable and
+      rerun the playbook.

--- a/roles/tendrl-ansible.tendrl-server/tasks/etcd-tls-client-auth-check.yml
+++ b/roles/tendrl-ansible.tendrl-server/tasks/etcd-tls-client-auth-check.yml
@@ -13,7 +13,7 @@
 - name: Gather information on etcd_trusted_ca_file
   stat:
     path: "{{ etcd_trusted_ca_file }}"
-  register: etcd_trusted_ca_file
+  register: etcd_trusted_ca
 
 - name: Check that file specified in etcd_cert_file actually exists
   assert:
@@ -36,7 +36,7 @@
 - name: Check that file specified in etcd_trusted_ca_file actually exists
   assert:
     that:
-      - etcd_trusted_ca_file.stat.exists == True
+      - etcd_trusted_ca.stat.exists == True
     msg: >
       File specified in etcd_trusted_ca_file doesn't exist on remote machine.
       Please specify path to trusted certificate authority in the variable and

--- a/roles/tendrl-ansible.tendrl-server/tasks/etcd-tls-client-auth-check.yml
+++ b/roles/tendrl-ansible.tendrl-server/tasks/etcd-tls-client-auth-check.yml
@@ -1,0 +1,43 @@
+---
+
+- name: Gather information on etcd_cert_file
+  stat:
+    path: "{{ etcd_cert_file }}"
+  register: etcd_crt
+
+- name: Gather information on etcd_key_file
+  stat:
+    path: "{{ etcd_key_file }}"
+  register: etcd_key
+
+- name: Gather information on etcd_trusted_ca_file
+  stat:
+    path: "{{ etcd_trusted_ca_file }}"
+  register: etcd_trusted_ca_file
+
+- name: Check that file specified in etcd_cert_file actually exists
+  assert:
+    that:
+      - etcd_crt.stat.exists == True
+    msg:
+      - "File specified in etcd_cert_file doesn't exist on remote machine."
+      - "Please specify path to etcd certificate file in the variable
+and rerun the playbook."
+
+- name: Check that file specified in etcd_key_file actually exists
+  assert:
+    that:
+      - etcd_key.stat.exists == True
+    msg:
+      - "File specified in etcd_key_file doesn't exist on remote machine."
+      - "Please specify path to etcd key file in the variable
+and rerun the playbook."
+
+- name: Check that file specified in etcd_trusted_ca_file actually exists
+  assert:
+    that:
+      - etcd_trusted_ca_file.stat.exists == True
+    msg:
+      - "File specified in etcd_trusted_ca_file doesn't exist on remote machine."
+      - "Please specify path to trusted certificate authority in the variable
+and rerun the playbook."

--- a/roles/tendrl-ansible.tendrl-server/tasks/etcd.yml
+++ b/roles/tendrl-ansible.tendrl-server/tasks/etcd.yml
@@ -40,6 +40,54 @@
 # https://coreos.com/etcd/docs/latest/op-guide/security.html
 #
 
+- name: Gather information on etcd_cert_file 
+  stat: 
+    path: "{{ etcd_cert_file }}"
+  register: etcd_crt
+  when: etcd_tls_client_auth|bool == True
+
+- name: Gather information on etcd_key_file
+  stat:
+    path: "{{ etcd_key_file }}"
+  register: etcd_key
+  when: etcd_tls_client_auth|bool == True
+
+- name: Gather information on etcd_trusted_ca_file
+  stat:
+    path: "{{ etcd_trusted_ca_file }}"
+  register: etcd_trusted_ca_file
+  when: etcd_tls_client_auth|bool == True
+
+- name: Check that file specified in etcd_cert_file actually exists
+  assert:
+    that:
+      - etcd_crt.stat.exists == True
+    msg:
+      - "File specified in etcd_cert_file doesn't exist on remote machine."
+      - "Please specify path to etcd certificate file in the variable
+and rerun the playbook."
+  when: etcd_tls_client_auth|bool == True
+
+- name: Check that file specified in etcd_key_file actually exists
+  assert:
+    that:
+      - etcd_key.stat.exists == True
+    msg:
+      - "File specified in etcd_key_file doesn't exist on remote machine."
+      - "Please specify path to etcd key file in the variable
+and rerun the playbook."
+  when: etcd_tls_client_auth|bool == True
+
+- name: Check that file specified in etcd_trusted_ca_file actually exists
+  assert:
+    that:
+      - etcd_trusted_ca_file.stat.exists == True
+    msg:
+      - "File specified in etcd_trusted_ca_file doesn't exist on remote machine."
+      - "Please specify path to trusted certificate authority in the variable
+and rerun the playbook."
+  when: etcd_tls_client_auth|bool == True
+
 - name: Configure etcd.conf ETCD_CERT_FILE (when TLS client auth is enabled)
   lineinfile:
     dest=/etc/etcd/etcd.conf

--- a/roles/tendrl-ansible.tendrl-server/tasks/etcd.yml
+++ b/roles/tendrl-ansible.tendrl-server/tasks/etcd.yml
@@ -40,52 +40,10 @@
 # https://coreos.com/etcd/docs/latest/op-guide/security.html
 #
 
-- name: Gather information on etcd_cert_file 
-  stat: 
-    path: "{{ etcd_cert_file }}"
-  register: etcd_crt
-  when: etcd_tls_client_auth|bool == True
-
-- name: Gather information on etcd_key_file
-  stat:
-    path: "{{ etcd_key_file }}"
-  register: etcd_key
-  when: etcd_tls_client_auth|bool == True
-
-- name: Gather information on etcd_trusted_ca_file
-  stat:
-    path: "{{ etcd_trusted_ca_file }}"
-  register: etcd_trusted_ca_file
-  when: etcd_tls_client_auth|bool == True
-
-- name: Check that file specified in etcd_cert_file actually exists
-  assert:
-    that:
-      - etcd_crt.stat.exists == True
-    msg:
-      - "File specified in etcd_cert_file doesn't exist on remote machine."
-      - "Please specify path to etcd certificate file in the variable
-and rerun the playbook."
-  when: etcd_tls_client_auth|bool == True
-
-- name: Check that file specified in etcd_key_file actually exists
-  assert:
-    that:
-      - etcd_key.stat.exists == True
-    msg:
-      - "File specified in etcd_key_file doesn't exist on remote machine."
-      - "Please specify path to etcd key file in the variable
-and rerun the playbook."
-  when: etcd_tls_client_auth|bool == True
-
-- name: Check that file specified in etcd_trusted_ca_file actually exists
-  assert:
-    that:
-      - etcd_trusted_ca_file.stat.exists == True
-    msg:
-      - "File specified in etcd_trusted_ca_file doesn't exist on remote machine."
-      - "Please specify path to trusted certificate authority in the variable
-and rerun the playbook."
+- name: Check if etcd cert files exists when TLS client auth is enabled
+  include_role:
+    name: tendrl-ansible.tendrl-server
+    tasks_from: etcd-tls-client-auth-check
   when: etcd_tls_client_auth|bool == True
 
 - name: Configure etcd.conf ETCD_CERT_FILE (when TLS client auth is enabled)

--- a/roles/tendrl-ansible.tendrl-storage-node/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-ansible.tendrl-storage-node/tasks/tendrl-node-agent.yml
@@ -22,52 +22,10 @@
   notify:
     - restart tendrl-node-agent
 
-- name: Gather information on etcd_cert_file
-  stat:
-    path: "{{ etcd_cert_file }}"
-  register: etcd_crt
-  when: etcd_tls_client_auth|bool == True
-
-- name: Gather information on etcd_key_file
-  stat:
-    path: "{{ etcd_key_file }}"
-  register: etcd_key
-  when: etcd_tls_client_auth|bool == True
-
-- name: Gather information on etcd_trusted_ca_file
-  stat:
-    path: "{{ etcd_trusted_ca_file }}"
-  register: etcd_trusted_ca_file
-  when: etcd_tls_client_auth|bool == True
-
-- name: Check that file specified in etcd_cert_file actually exists
-  assert:
-    that:
-      - etcd_crt.stat.exists == True
-    msg:
-      - "File specified in etcd_cert_file doesn't exist on remote machine."
-      - "Please specify path to etcd certificate file in the variable
-        and rerun the playbook."
-  when: etcd_tls_client_auth|bool == True
-
-- name: Check that file specified in etcd_key_file actually exists
-  assert:
-    that:
-      - etcd_key.stat.exists == True
-    msg:
-      - "File specified in etcd_key_file doesn't exist on remote machine."
-      - "Please specify path to etcd key file in the variable
-and rerun the playbook."
-  when: etcd_tls_client_auth|bool == True
-
-- name: Check that file specified in etcd_trusted_ca_file actually exists
-  assert:
-    that:
-      - etcd_trusted_ca_file.stat.exists == True
-    msg:
-      - "File specified in etcd_trusted_ca_file doesn't exist on remote machine."
-      - "Please specify path to trusted certificate authority in the variable
-and rerun the playbook."
+- name: Check if etcd cert files exists when TLS client auth is enabled
+  include_role:
+    name: tendrl-ansible.tendrl-server
+    tasks_from: etcd-tls-client-auth-check
   when: etcd_tls_client_auth|bool == True
 
 - name: Configure etcd client-server authentication

--- a/roles/tendrl-ansible.tendrl-storage-node/tasks/tendrl-node-agent.yml
+++ b/roles/tendrl-ansible.tendrl-storage-node/tasks/tendrl-node-agent.yml
@@ -22,6 +22,54 @@
   notify:
     - restart tendrl-node-agent
 
+- name: Gather information on etcd_cert_file
+  stat:
+    path: "{{ etcd_cert_file }}"
+  register: etcd_crt
+  when: etcd_tls_client_auth|bool == True
+
+- name: Gather information on etcd_key_file
+  stat:
+    path: "{{ etcd_key_file }}"
+  register: etcd_key
+  when: etcd_tls_client_auth|bool == True
+
+- name: Gather information on etcd_trusted_ca_file
+  stat:
+    path: "{{ etcd_trusted_ca_file }}"
+  register: etcd_trusted_ca_file
+  when: etcd_tls_client_auth|bool == True
+
+- name: Check that file specified in etcd_cert_file actually exists
+  assert:
+    that:
+      - etcd_crt.stat.exists == True
+    msg:
+      - "File specified in etcd_cert_file doesn't exist on remote machine."
+      - "Please specify path to etcd certificate file in the variable
+        and rerun the playbook."
+  when: etcd_tls_client_auth|bool == True
+
+- name: Check that file specified in etcd_key_file actually exists
+  assert:
+    that:
+      - etcd_key.stat.exists == True
+    msg:
+      - "File specified in etcd_key_file doesn't exist on remote machine."
+      - "Please specify path to etcd key file in the variable
+and rerun the playbook."
+  when: etcd_tls_client_auth|bool == True
+
+- name: Check that file specified in etcd_trusted_ca_file actually exists
+  assert:
+    that:
+      - etcd_trusted_ca_file.stat.exists == True
+    msg:
+      - "File specified in etcd_trusted_ca_file doesn't exist on remote machine."
+      - "Please specify path to trusted certificate authority in the variable
+and rerun the playbook."
+  when: etcd_tls_client_auth|bool == True
+
 - name: Configure etcd client-server authentication
   lineinfile:
     dest: /etc/tendrl/node-agent/node-agent.conf.yaml


### PR DESCRIPTION
Add the checks that the files specified in etcd_cert_file, etcd_key_file and etcd_trusted_ca_file actually exist if etcd_tls_client_auth is set to True.

Fixing: https://github.com/Tendrl/tendrl-ansible/issues/111