### PR TITLE
tendrl-server: no longer open 3000/tcp for grafana

### DIFF
--- a/roles/tendrl-ansible.tendrl-server/tasks/firewalld.yml
+++ b/roles/tendrl-ansible.tendrl-server/tasks/firewalld.yml
@@ -33,13 +33,6 @@
     state=enabled
     immediate=true
 
-- name: Enable port for grafana server
-  firewalld:
-    port=3000/tcp
-    permanent=yes
-    state=enabled
-    immediate=true
-
 - name: Enable port for tendrl-monitoring-integration (grafana alerts callback)
   firewalld:
     port=8789/tcp


### PR DESCRIPTION
Since grafana is going to be available via httpd, it's no longer
necessary to open port 3000/tcp on tendrl-server.

tendrl-bug-id: https://github.com/Tendrl/tendrl-ansible/issues/127