### PR TITLE
Added cleanup meachnism for tendrl setup

### DIFF
--- a/cleanup.yml
+++ b/cleanup.yml
@@ -1,0 +1,29 @@
+---
+# This Ansible playbook is to cleanup Tendrl setup
+# It just stops all the running services related to Tendrl
+# on storage nodes as well as server. Also it cleans the
+# existing etcd, grafana and carbon data (if any) for existing
+# setup
+
+- hosts: gluster_servers
+  user: root
+
+  roles:
+    - tendrl-storage-node-cleanup
+
+- hosts: tendrl_server
+  user: root
+  vars:
+    # etcd db file to be deleted
+    etcd_db_path: "/var/lib/etcd/default.etcd"
+
+    # grafana db file to be deleted
+    grafana_db_file: "/var/lib/grafana/grafana.db"
+
+    # carbon data to be deleted
+    carbon_data_path: "/var/lib/carbon/whisper/tendrl/"
+
+  roles:
+    - tendrl-server-cleanup
+
+

--- a/roles/tendrl-ansible.tendrl-server-cleanup/main.yml
+++ b/roles/tendrl-ansible.tendrl-server-cleanup/main.yml
@@ -1,0 +1,42 @@
+---
+# Task file for storage nodes
+
+- name: Stop tendrl services
+  service:
+    name: tendrl-node-agent
+    state: stopped
+
+- name: Stop etcd service
+  service:
+    name: etcd
+    state: stopped
+
+- name: Stop grafana-server service
+  service:
+    name: grafana-server
+    state: stopped
+
+- name: Stop carbon-cache service
+  service:
+    name: carbon-cache
+    state: stopped
+
+- name: Stop httpd service
+  service:
+    name: httpd
+    state: stopped
+
+- name: Cleanup etcd data
+  file:
+    path: "{{etcd_db_path}}/"
+    state: absent
+
+- name: Cleanup grafana data
+  file:
+    path: "{{grafana_db_file}}"
+    state: absent
+
+- name: Cleanup carbon data
+  file:
+    path: "{{carbon_data_path}}/"
+    state: absent

--- a/roles/tendrl-ansible.tendrl-storage-node-cleanup/main.yml
+++ b/roles/tendrl-ansible.tendrl-storage-node-cleanup/main.yml
@@ -1,0 +1,18 @@
+
+---
+# Task file for storage nodes
+
+- name: Stop tendrl services
+  service:
+    name: tendrl-gluster-integration
+    state: stopped
+
+- name: Stop tendrl services
+  service:
+    name: tendrl-node-agent
+    state: stopped
+
+- name: Stop collectd
+  service:
+    name: collectd
+    state: stopped


### PR DESCRIPTION
The cleanup playbook performs the below steps
- Stops collectd, tendrl-node-agent and tendrl-gluster-integration
on storage nodes
- Stops tendrl-node-agent, tendrl-monitoring-integration, tendrl-notifier,
tendrl-api on tendrl server node
- Stops grafana-server, carbon-cache and etcd services on storage nodes
- Cleans up etcd, grafana and carbon data files

tendrl-bug-id: Tendrl/tendrl-ansible/issues/63
Signed-off-by: Shubhendu <shtripat@redhat.com>