### PR TITLE
Added new taks under monitoring-integration to update grafana root_url with subpath for reverse proxy

### DIFF
--- a/roles/tendrl-ansible.tendrl-server/tasks/tendrl-monitoring-integration.yml
+++ b/roles/tendrl-ansible.tendrl-server/tasks/tendrl-monitoring-integration.yml
@@ -81,13 +81,12 @@
     - restart grafana-server
 
 - name: Configure grafana root_url with sub_path for reverse proxy
-  lineinfile:
-    dest=/etc/tendrl/monitoring-integration/grafana/grafana.ini
-    regexp={{ item.regexp }}
-    line={{ item.line }}
-  with_items:
-    - regexp: '^;? *root_url = .*'
-      line: "root_url = http://localhost:3000/grafana"
+  ini_file:
+    path: /etc/tendrl/monitoring-integration/grafana/grafana.ini
+    section: server
+    option: root_url
+    value: "http://localhost:3000/grafana"
+    state: present
   notify:
     - restart grafana-server
 

--- a/roles/tendrl-ansible.tendrl-server/tasks/tendrl-monitoring-integration.yml
+++ b/roles/tendrl-ansible.tendrl-server/tasks/tendrl-monitoring-integration.yml
@@ -80,6 +80,10 @@
   notify:
     - restart grafana-server
 
+#
+# This task is only for update scenario and will not affect on fresh installation
+#
+
 - name: Configure grafana root_url with sub_path for reverse proxy
   ini_file:
     path: /etc/tendrl/monitoring-integration/grafana/grafana.ini

--- a/roles/tendrl-ansible.tendrl-server/tasks/tendrl-monitoring-integration.yml
+++ b/roles/tendrl-ansible.tendrl-server/tasks/tendrl-monitoring-integration.yml
@@ -80,6 +80,17 @@
   notify:
     - restart grafana-server
 
+- name: Configure grafana root_url with sub_path for reverse proxy
+  lineinfile:
+    dest=/etc/tendrl/monitoring-integration/grafana/grafana.ini
+    regexp={{ item.regexp }}
+    line={{ item.line }}
+  with_items:
+    - regexp: '^;? *root_url = .*'
+      line: "root_url = http://localhost:3000/grafana"
+  notify:
+    - restart grafana-server
+
 - name: Enable grafana-server service
   systemd:
     name=grafana-server


### PR DESCRIPTION

tendrl-bug-id: Tendrl/tendrl-ansible#130
bugzilla: 1650557

Signed-off-by: GowthamShanmugasundaram <gshanmug@redhat.com>