### PR TITLE
Restricting graphite-web port form outside access

### DIFF
--- a/roles/tendrl-ansible.tendrl-server/tasks/firewalld.yml
+++ b/roles/tendrl-ansible.tendrl-server/tasks/firewalld.yml
@@ -19,13 +19,6 @@
     state=enabled
     immediate=true
 
-- name: Enable port for Graphite web
-  firewalld:
-    port=10080/tcp
-    permanent=yes
-    state=enabled
-    immediate=true
-
 - name: Enable port for http
   firewalld:
     port=80/tcp


### PR DESCRIPTION
bugzilla: 1655433
tendrl-bug-id: Tendrl/tendrl-ansible#135

Signed-off-by: GowthamShanmugasundaram <gshanmug@redhat.com>