### PR TITLE
tendrl-storage-node: install tendrl-gluster-integration [blocked]

### DIFF
--- a/roles/tendrl-ansible.tendrl-storage-node/tasks/main.yml
+++ b/roles/tendrl-ansible.tendrl-storage-node/tasks/main.yml
@@ -17,6 +17,7 @@
 
 - include: rsyslog.yml
 - include: tendrl-node-agent.yml
+- include: tendrl-gluster-integration.yml
 - include: firewalld.yml
   when: configure_firewalld_for_tendrl == True
   tags:

--- a/roles/tendrl-ansible.tendrl-storage-node/tasks/tendrl-gluster-integration.yml
+++ b/roles/tendrl-ansible.tendrl-storage-node/tasks/tendrl-gluster-integration.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Install tendrl-gluster-integration
+  yum:
+    name: tendrl-gluster-integration
+    state: latest
+  tags:
+    - rpm-installation
+
+# Nothing else beyond sheer installation is done here, as the rest is
+# configured by Tendrl itself during import cluster operation, see:
+# https://github.com/Tendrl/tendrl-ansible/issues/126#issuecomment-449099471


### PR DESCRIPTION
Install tendrl-gluster-integration on all storage nodes. This package
was previously installed during import cluster operation and installing
it here should work no matter if the package is installed during import
or not.

Fixing https://github.com/Tendrl/tendrl-ansible/issues/126

Blocked by https://github.com/Tendrl/commons/issues/1073